### PR TITLE
fixed - access private constant in api controller

### DIFF
--- a/Model/Config/Source/LoggingStatus.php
+++ b/Model/Config/Source/LoggingStatus.php
@@ -13,8 +13,8 @@ use Magento\Framework\Data\OptionSourceInterface;
  */
 class LoggingStatus implements OptionSourceInterface
 {
-    private const ENABLED_FOR_ALL = 1;
-    private const ENABLED_FOR_SPECIFIC = 2;
+    const ENABLED_FOR_ALL = 1;
+    const ENABLED_FOR_SPECIFIC = 2;
     private const DISABLED = 0;
 
     /**


### PR DESCRIPTION
Hi, I Hope you are doing well.
In this PR, I fixed a problem with the private access constant issue where it causes an exception in rest APIs when logging is enabled.
```
Error: Cannot access private constant Moses\Log\Model\Config\Source\LoggingStatus::ENABLED_FOR_ALL in /home/amooati/public_html/vendor/moses/magento-log/Plugin/Magento/Webapi/Controller/RestPlugin.php:96
Stack trace:
#0 /home/amooati/public_html/vendor/moses/magento-log/Plugin/Magento/Webapi/Controller/RestPlugin.php(69): Moses\Log\Plugin\Magento\Webapi\Controller\RestPlugin->canLog()
#1 /home/amooati/public_html/vendor/magento/framework/Interception/Interceptor.php(146): Moses\Log\Plugin\Magento\Webapi\Controller\RestPlugin->afterDispatch()
#2 /home/amooati/public_html/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Webapi\Controller\Rest\Interceptor->Magento\Framework\Interception\{closure}()
#3 /home/amooati/public_html/generated/code/Magento/Webapi/Controller/Rest/Interceptor.php(23): Magento\Webapi\Controller\Rest\Interceptor->___callPlugins()
#4 /home/amooati/public_html/vendor/magento/framework/App/Http.php(116): Magento\Webapi\Controller\Rest\Interceptor->dispatch()
#5 /home/amooati/public_html/vendor/magento/framework/App/Bootstrap.php(264): Magento\Framework\App\Http->launch()
#6 /home/amooati/public_html/pub/index.php(30): Magento\Framework\App\Bootstrap->run()
#7 {main}
```
These constants are used in `Moses\Log\Plugin\Magento\Webapi\Controller\RestPlugin`